### PR TITLE
Selected items keep git status color

### DIFF
--- a/styles/lists.less
+++ b/styles/lists.less
@@ -26,6 +26,12 @@
   .selected {
     color: @text-color-selected;
   }
+  .status-modified {
+    color: @text-color-warning;
+  }
+  .status-added {
+    color: @text-color-success;
+  }
 }
 
 

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -21,4 +21,10 @@
   .list-item.selected {
     color: @text-color-selected;
   }
+  .list-item.status-modified {
+    color: @text-color-warning;
+  }
+  .list-item.status-added {
+    color: @text-color-success;
+  }
 }


### PR DESCRIPTION
When an item is selected it turns white and you lose git-status color hint.

>![atom neutral-gray-ui screenshot1](https://user-images.githubusercontent.com/7262829/31791207-2e82d0c2-b518-11e7-9aaa-83932743cd7e.png)
>Before

>![atom neutral-gray-ui screenshot2](https://user-images.githubusercontent.com/7262829/31791210-30047bda-b518-11e7-8685-563003ef1af3.png)
>After. It keeps status-modified color

This changes works for added or modified folders and files.

I hope this PR is ok . 
Thank you!